### PR TITLE
some bug fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,28 @@
-FROM debian:buster
+FROM ubuntu:bionic 
 
 # Maintainer
-LABEL maintainer "Alexander Graf <alex@otherguy.io>"
+LABEL maintainer="Tony Pan <tcp1975@gmail.com>"
 
 # Build arguments
 ARG VCS_REF=master
 ARG BUILD_DATE=""
 
 # http://label-schema.org/rc1/
-LABEL org.label-schema.schema-version "1.0"
-LABEL org.label-schema.name           "Dropbox"
-LABEL org.label-schema.build-date     "${BUILD_DATE}"
-LABEL org.label-schema.description    "Standalone Dropbox client on Linux"
-LABEL org.label-schema.vcs-url        "https://github.com/otherguy/docker-dropbox"
-LABEL org.label-schema.vcs-ref        "${VCS_REF}"
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="Dropbox"
+LABEL org.label-schema.build-date="${BUILD_DATE}"
+LABEL org.label-schema.description="Standalone Dropbox client on Linux"
+LABEL org.label-schema.vcs-url="https://github.com/tcpan/docker-dropbox"
+LABEL org.label-schema.vcs-ref="${VCS_REF}"
 
 # Required to prevent warnings
-ENV DEBIAN_FRONTEND noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
 RUN apt-get update \
- && apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gnupg2 software-properties-common gosu locales locales-all unzip build-essential
+ && apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gnupg2 software-properties-common gosu locales locales-all unzip build-essential \
+ && apt-get autoclean -y && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
 
 # Create user and group
 RUN mkdir -p /opt/dropbox /opt/dropbox/.dropbox /opt/dropbox/Dropbox \
@@ -44,9 +46,10 @@ EXPOSE 17500
 
 # https://help.dropbox.com/installs-integrations/desktop/linux-repository
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FC918B335044912E \
- && add-apt-repository 'deb http://linux.dropbox.com/debian buster main' \
+ && add-apt-repository 'deb http://linux.dropbox.com/ubuntu bionic main' \
  && apt-get update \
  && apt-get install -y --no-install-recommends libatomic1 python3-gpg dropbox \
+ && apt-get autoclean -y && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
 RUN curl --location https://github.com/dark/dropbox-filesystem-fix/archive/master.zip > /tmp/dropbox-filesystem-fix.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 # Install prerequisites
 RUN apt-get update \
- && apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gnupg2 software-properties-common gosu locales locales-all unzip build-essential \
+ && apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gnupg2 software-properties-common gosu locales locales-all unzip build-essential tzdata \
  && apt-get autoclean -y && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi,
I ran into a few bugs when trying to use the dropbox docker container, and I went ahead an fixed them (as far as I can tell):
1. switched to ubuntu base image, as it is officially supported by dropbox and also does not cause some warnings observed via "docker logs"
2. syntax of LABEL lines in Dockerfile was incorrect.
3. DEBIAN_DRONTEND line has been changed to ARG - this makes the variable a build time variable only.
4. installed tzdata, so that container can be started with --volume=/etc/timezone:/etc/timezone and --volume=/etc/localtime:/etc/localtime.  This fixes the problem of host on local time zone and container defaulting to UTC.  Dropbox probably is not checking time zones when comparing file timestamps, leading to file overwrites and data loss.

I ended up not using docker containers for dropbox, but thought I pass along these fixes.   Please feel free to remove my username/email from the Dockerfile.   Enjoy!

Tony