### PR TITLE
Rework use of volumes so that Dropbox can create its own Dropbox folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Based on Ubuntu 21.10
-FROM ubuntu:21.10
+# Based on Ubuntu 22.04
+FROM ubuntu:22.04
 
 # Maintainer
 LABEL maintainer "Alexander Graf <alex@otherguy.io>"
@@ -9,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG DEBCONF_NONINTERACTIVE_SEEN=true
 
 # Change working directory
-WORKDIR /opt/dropbox/Dropbox
+WORKDIR /opt/dropbox
 
 # Not really required for --net=host
 EXPOSE 17500
@@ -21,42 +21,19 @@ ENV LC_ALL "C.UTF-8"
 # Install prerequisites
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-   software-properties-common gnupg2 curl \
+   software-properties-common gnupg2 curl wget \
    libglapi-mesa libxext-dev libxdamage-dev libxshmfence-dev libxxf86vm-dev \
    libxcb-glx0 libxcb-dri2-0 libxcb-dri3-0 libxcb-present-dev \
    ca-certificates gosu tzdata libc6 libxdamage1 libxcb-present0 \
    libxcb-sync1 libxshmfence1 libxxf86vm1 python3-gpg
 
 # Create user and group
-RUN mkdir -p /opt/dropbox /opt/dropbox/.dropbox /opt/dropbox/Dropbox \
+RUN mkdir -p /opt/dropbox \
  && useradd --home-dir /opt/dropbox --comment "Dropbox Daemon Account" --user-group --shell /usr/sbin/nologin dropbox \
  && chown -R dropbox:dropbox /opt/dropbox
 
-# https://help.dropbox.com/installs-integrations/desktop/linux-repository
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FC918B335044912E \
- && add-apt-repository 'deb http://linux.dropbox.com/debian buster main' \
- && apt-get update \
- && apt-get -qqy install dropbox \
- && apt-get -qqy autoclean \
- && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Dropbox insists on downloading its binaries itself via 'dropbox start -i'
-RUN echo "y" | gosu dropbox dropbox start -i
-
-# Dropbox has the nasty tendency to update itself without asking. In the processs it fills the
-# file system over time with rather large files written to /opt/dropbox/ and /tmp.
-#
-# https://bbs.archlinux.org/viewtopic.php?id=191001
-RUN mkdir -p /opt/dropbox/bin/ /tmp \
- && mv /opt/dropbox/.dropbox-dist/* /opt/dropbox/bin/ \
- && rm -rf /opt/dropbox/.dropbox-dist \
- && install -dm0 /opt/dropbox/.dropbox-dist \
- && chmod u-w /opt/dropbox/.dropbox-dist \
- && chmod o-w /tmp \
- && chmod g-w /tmp
-
 # Create volumes
-VOLUME ["/opt/dropbox/.dropbox", "/opt/dropbox/Dropbox"]
+VOLUME ["/opt/dropbox"]
 
 # Build arguments
 ARG VCS_REF=main

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ are explained in the sections below.
       -e "DROPBOX_UID=$(id -u)" \
       -e "DROPBOX_GID=$(id -g)" \
       -e "POLLING_INTERVAL=20" \
-      -v "/path/to/local/settings:/opt/dropbox/.dropbox" \
+      -v "/path/to/local/settings:/opt/dropbox" \
       -v "/path/to/local/dropbox:/opt/dropbox/Dropbox" \
       otherguy/dropbox:latest
 
@@ -174,16 +174,20 @@ If this is set to `true`, the container skips setting the permissions on all fil
 in order to prevent long startup times. _Note:_ please make sure to have correct permissions on all files before
 you do this! Implemented for [#25](https://github.com/otherguy/docker-dropbox/issues/25).
 
-### Exposed Volumes
+### Volumes
+
+- `/opt/dropbox`
+This represents the daemon user's home directory in the container. On the host, it will be populated with some binaries, some configuration, account settings, and other settings for Dropbox. If you don't mount this folder, your account needs to be linked every time you restart the container.
 
 - `/opt/dropbox/Dropbox`
-The actual Dropbox folder, containing all your synced files.
+The actual Dropbox folder, containing all your synced files. Note that you may need to omit this on the first run so that Dropbox can have control to create it. Once it is created in the other volume, you can recreate the container with this volume as well.
 
-- `/opt/dropbox/.dropbox`
-Account and other settings for Dropbox. If you don't mount this folder, your account needs to be linked
-every time you restart the container.
 
 ## 🤨 Questions and Gotchas
+
+### "Dropbox needs to rename your existing folder or file named Dropbox to finish installing"
+
+Dropbox may fail with this error message present in logs (visible with `docker logs`). If this happens, you'll need to run the container once without the `/opt/dropbox/Dropbox` volume. See the notes on this above.
 
 ### Monitoring more than 10,000 folders on Linux
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,7 +48,7 @@ else
 fi
 
 # Change permissions on Dropbox folder
-chmod 755 /opt/dropbox/Dropbox
+[[ -d /opt/dropbox/Dropbox ]] && chmod 755 /opt/dropbox/Dropbox
 
 #  Dropbox did not shutdown properly? Remove files.
 [ ! -e "/opt/dropbox/.dropbox/command_socket" ] || rm /opt/dropbox/.dropbox/command_socket
@@ -57,7 +57,7 @@ chmod 755 /opt/dropbox/Dropbox
 [ ! -e "/opt/dropbox/.dropbox/dropbox.pid" ]    || rm /opt/dropbox/.dropbox/dropbox.pid
 
 # Update Dropbox to latest version unless DROPBOX_SKIP_UPDATE is set
-if [[ -z "$DROPBOX_SKIP_UPDATE" ]]; then
+if [[ -z "$DROPBOX_SKIP_UPDATE" ]] || [[ ! -f /opt/dropbox/bin/VERSION ]]; then
   echo "Checking for latest Dropbox version..."
   sleep 1
 
@@ -71,10 +71,27 @@ if [[ -z "$DROPBOX_SKIP_UPDATE" ]]; then
   Latest=$(echo $DL | sed 's/.*x86_64-\([0-9]*\.[0-9]*\.[0-9]*\)\.tar\.gz/\1/')
 
   # Get current Version
-  Current=$(cat /opt/dropbox/bin/VERSION)
+  if [[ -f /opt/dropbox/bin/VERSION ]]; then
+    Current=$(cat /opt/dropbox/bin/VERSION)
+  else
+    Current="Not installed"
+  fi
+
+  if [[ ! -d /opt/dropbox/bin ]]; then
+    # Dropbox has the nasty tendency to update itself without asking. In the processs it fills the
+    # file system over time with rather large files written to /opt/dropbox/ and /tmp.
+    #
+    # https://bbs.archlinux.org/viewtopic.php?id=191001
+    mkdir -p /opt/dropbox/bin/ /tmp \
+    && install -dm0 /opt/dropbox/.dropbox-dist \
+    && chmod u-w /opt/dropbox/.dropbox-dist \
+    && chmod o-w /tmp \
+    && chmod g-w /tmp
+  fi
+
   echo "Latest   :" $Latest
   echo "Installed:" $Current
-  if [ ! -z "${Latest}" ] && [ ! -z "${Current}" ] && [ $Current != $Latest ]; then
+  if [ ! -z "${Latest}" ] && [ ! -z "${Current}" ] && [ "$Current" != "$Latest" ]; then
   	echo "Downloading Dropbox $Latest..."
   	tmpdir=`mktemp -d`
   	curl -# -L $DL | tar xzf - -C $tmpdir
@@ -87,6 +104,15 @@ if [[ -z "$DROPBOX_SKIP_UPDATE" ]]; then
   else
     echo "Dropbox is up-to-date"
   fi
+fi
+
+# Get the CLI script
+# https://help.dropbox.com/installs/linux-commands
+if [[ ! -f /opt/dropbbox.py ]]; then
+  wget -O /opt/dropbox.py https://www.dropbox.com/download?dl=packages/dropbox.py
+  echo "#!/bin/bash" > /usr/bin/dropbox
+  echo "python3 /opt/dropbox.py \"\$@\"" >> /usr/bin/dropbox
+  chmod +x /usr/bin/dropbox
 fi
 
 # Empty line


### PR DESCRIPTION
Changes the volumes so that one encompasses the other and Dropbox can create its own Dropbox folder. This can be used to work around issues on the first run mentioned in https://github.com/otherguy/docker-dropbox/issues/60.

Note that Dropbox won't accept the Dropbox folder on overlayfs, so it needs to be on some volume even during the first run; this is why it was needed to change the other volume from `/opt/dropbox/.dropbox` to something that would contain the new Dropbox folder.

I found that whatever version of Dropbox is in the repository they manage doesn't seem to match the expectations of the build script anymore, so I had to start reworking it. Thus, I simplified the installation process to happen during the first run instead of during the image build. It is now entirely from the downloaded tar and a downloaded CLI script instead of from a repository. Binaries are now stored in the /opt/dropbox volume, which you could argue is a little messy, but I'm not inclined right now to relocate them.

While I was at it, I updated to a LTS Ubuntu version. I was having issues building on 21.10.